### PR TITLE
Don't lint "unused" vars if they are TypeScript function signature params

### DIFF
--- a/api/eslint.config.mjs
+++ b/api/eslint.config.mjs
@@ -54,8 +54,6 @@ export default [
         },
       ],
 
-      "no-unused-vars": 1,
-
       "no-warning-comments": [
         0,
         {

--- a/api/src/middlewares/handle-errors.ts
+++ b/api/src/middlewares/handle-errors.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 

--- a/api/src/middlewares/is-authorized.ts
+++ b/api/src/middlewares/is-authorized.ts
@@ -1,5 +1,3 @@
-/* eslint-disable no-unused-vars */
-
 import { Request, Response, NextFunction } from "express";
 
 import { HttpError } from "../utils/http-error";

--- a/api/src/services/stream/inout-stream.ts
+++ b/api/src/services/stream/inout-stream.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 import { Duplex, DuplexOptions } from "stream";

--- a/api/src/services/ws/scheduler.ts
+++ b/api/src/services/ws/scheduler.ts
@@ -1,7 +1,6 @@
 import { logger } from "../../../src/config/logger";
 
 interface Scheduler {
-  // eslint-disable-next-line no-unused-vars
   start: (callback: () => void, interfval: number) => void;
   stop: () => void;
   timerId?: NodeJS.Timeout;

--- a/api/src/services/ws/ws-client-store.ts
+++ b/api/src/services/ws/ws-client-store.ts
@@ -1,4 +1,3 @@
-/* eslint-disable no-unused-vars */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 
 import EventEmitter from "events";

--- a/api/tsconfig.json
+++ b/api/tsconfig.json
@@ -14,7 +14,7 @@
     "outDir": "./build",
     "strict": true,
     "moduleResolution": "node",
-    "noUnusedLocals": false,
+    "noUnusedLocals": true,
     "noImplicitReturns": true,
     "noImplicitAny": true,
     "noFallthroughCasesInSwitch": true,


### PR DESCRIPTION
#132 